### PR TITLE
scrape_with.yml: Fix repository URL

### DIFF
--- a/scrape_with.yml
+++ b/scrape_with.yml
@@ -1,7 +1,7 @@
 name: Scrape With
 description: Run fragment based scrapers on fragment based scrapers ie tag a scene with scrape_with_xbvr and start the action.
 version: 0.4
-url: https://github.com/tweeticoats/scrape-with-plugin
+url: https://github.com/Tweeticoats/scrape-with-plugin
 exec:
  - python3
  - "{pluginDir}/scrape_with.py"


### PR DESCRIPTION
(GitHub links are case-sensitive.)

When you click the link icon from Stash Plugins UI, it currently goes to a broken link.  This PR fixes it!

Cheerio maytey